### PR TITLE
Fix: Empty array reduce error

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -14,6 +14,7 @@ const getFromRedis = promisify(client.get).bind(client)
 const getCache = (key) =>
   getFromRedis(key)
     .then(JSON.parse)
+    .then( (response) => response ? response : Promise.reject() )
 
 const setCache = (key, value) => {
   client.set(key, JSON.stringify(value), 'EX', TTL)


### PR DESCRIPTION
O erro na verdade começou a ocorrer por causa que ao retornar vazio, o cache não mostrava erro.